### PR TITLE
to_json before assigning request body

### DIFF
--- a/lib/eleyo/api/account.rb
+++ b/lib/eleyo/api/account.rb
@@ -77,7 +77,7 @@ module Eleyo
 
         request = HTTPI::Request.new
         request.url = "#{api_route}/users/#{uuid}"
-        request.body = params
+        request.body = params.to_json
         request.headers = self.generate_headers
 
         response = HTTPI.put(request)


### PR DESCRIPTION
Make the `params` into JSON before sending to accounts for an update.